### PR TITLE
[Arreglar] Color de fondo para Firefox

### DIFF
--- a/assets/styles/pages/signup/signup.css
+++ b/assets/styles/pages/signup/signup.css
@@ -40,6 +40,14 @@ body {
     opacity: 0.8;
 }
 
+@-moz-document url-prefix() {  
+    body {
+        background-blend-mode: none;
+        background: rgb(192,179,214);
+        background: linear-gradient(0deg, rgba(192,179,214,1) 0%, rgba(166,177,212,1) 100%);
+    } /* Firefox */
+}
+
 /* Contenedor */
 
 .wrapper {


### PR DESCRIPTION
Había un pequeño bug con firefox ya que el color de fondo para el login y el signup no respetaba los parámetros establecidos en la hoja de estilos.